### PR TITLE
fix: unselected build leads to workflow deploy failure

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 shamefullyHoist: true
 onlyBuiltDependencies:
   - esbuild
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
直播时 silvaire 看我搞半天一无所获，结果 ta 睡了我修好了（）

个人认为姑且有合入上游的价值，特开此请求。~~这项目毕竟也不是我的，我还是不搞破坏（指`push -f`）力。~~

在本地开 docker 排查发现，全新安装的情况下包管理器未能确认由谁构建，build 失败：
```bash
[root@307aeb81bf07 blogs]# pnpm build
Lockfile is up to date, resolution step is skipped
Already up to date
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.21.5

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
[ERROR] Command failed with exit code 1: ...
```